### PR TITLE
made check_varnish.c compatible with varnishapi again

### DIFF
--- a/check_varnish.c
+++ b/check_varnish.c
@@ -196,7 +196,7 @@ check_stats_cb(void *priv, const struct VSC_point * const pt)
 		(pt->section->fantom->ident[0] == 0 ? "" : "."),
 		 pt->desc->name);
 	p = priv;
-	assert(!strcmp(pt->desc->fmt, "uint64_t"));
+	assert(!strcmp(pt->desc->ctype, "uint64_t"));
 #elif defined(HAVE_VARNISHAPI_3)
 	assert(sizeof(tmp) > (strlen(pt->class) + 1 +
 			      strlen(pt->ident) + 1 +


### PR DESCRIPTION
This is what I had to change to compile varnish-nagios again (on FreeBSD). The simple change is to fix what commit varnish/Varnish-Cache@96f5919e56f4a5895c53e9bfc98cf643c4ea0ca6 broke