### PR TITLE
remove the use of the undeclared and unused VSC_ARGS macros (its valu…

### DIFF
--- a/check_varnish.c
+++ b/check_varnish.c
@@ -326,7 +326,7 @@ main(int argc, char **argv)
 	VSC_Setup(vd);
 #endif
 
-	while ((opt = getopt(argc, argv, VSC_ARGS "c:hn:p:vw:")) != -1) {
+	while ((opt = getopt(argc, argv, "c:hn:p:vw:")) != -1) {
 		switch (opt) {
 		case 'c':
 			if (parse_range(optarg, &critical) != 0)


### PR DESCRIPTION
…e is "f:n:N:")

This macro isn't included in varnish 5.1 anymore and the options aren't used.